### PR TITLE
Terraform data to get Cent OS AMIs

### DIFF
--- a/aws/terraform/data/centos/main.tf
+++ b/aws/terraform/data/centos/main.tf
@@ -1,0 +1,14 @@
+data "aws_ami" "this" {
+  # https://wiki.centos.org/Cloud/AWS
+  # The current official AMIs are published outside of the AWS Marketplace and are shared directly from official CPE account 125523088429.
+  owners = ["125523088429"]
+
+  most_recent = true
+
+  # It would be better to filter by platform, but currently, platform value is Windows for Windows AMIs; otherwise, blank.
+  filter {
+    name   = "name"
+    values = ["CentOS*${var.os_version}*${var.arch}*"]
+  }
+
+}

--- a/aws/terraform/data/centos/outputs.tf
+++ b/aws/terraform/data/centos/outputs.tf
@@ -1,0 +1,6 @@
+output "ami_id" {
+  value = data.aws_ami.this.id
+}
+output "ami" {
+  value = data.aws_ami.this
+}

--- a/aws/terraform/data/centos/variables.tf
+++ b/aws/terraform/data/centos/variables.tf
@@ -1,0 +1,11 @@
+variable "os_version" {
+  description = "OS version"
+  type        = string
+  default     = "8.2"
+}
+
+variable "arch" {
+  description = "Specifies the architecture of the AMI, e.g. i386 for 32-bit, or x86_64 for 64-bit."
+  type        = string
+  default     = "x86_64"
+}

--- a/tests/aws_terraform_centos_ami_test.go
+++ b/tests/aws_terraform_centos_ami_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test if Terraform returns a valid Cent OS AMI using Terratest.
+func TestAwsTerraformCentosAmi(t *testing.T) {
+	t.Parallel()
+
+	expectedAmi := "ami-"
+	osVersion := "8.2"
+	arch := "x86_64"
+	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../aws/terraform/data/centos",
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"os_version": osVersion,
+			"arch":       arch,
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+
+		// Disable colors in Terraform commands so its easier to parse stdout/stderr
+		NoColor: true,
+	})
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the values of output variables
+	actualAmi := terraform.Output(t, terraformOptions, "ami_id")
+
+	// Verify we're getting back the outputs we expect
+	assert.Contains(t, actualAmi, expectedAmi)
+}


### PR DESCRIPTION
## Proposed changes

This feature allows us to fetch the latest official CentOS AMI based on the OS version and CPU architecture.
https://wiki.centos.org/Cloud/AWS

## Types of changes

What types of changes does your code introduce to Remote Development?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/DanielRDias/remote-development/blob/main/CONTRIBUTING.md) doc
- [x] Commits follow the [Angular commit convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)

